### PR TITLE
Code coverage by Codecov and tests for 7.n

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    - CODECOV_TOKEN="62cd0951-8539-4fa1-b1c5-3793e2b50e2a"
+
 language: php
 
 php:
@@ -5,13 +9,15 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - 7.1
 
 before_script:
-  - composer self-update
-  - composer install
-  - pear install PHP_CodeSniffer
-  - phpenv rehash
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - phpcs --standard=psr2 src/
-  - phpunit --coverage-text
+  - vendor/bin/phpunit --coverage-clover=coverage.xml
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shelf
 
-[![PHP version](https://badge.fury.io/ph/oscarpalmer%2Fshelf.png)](http://badge.fury.io/ph/oscarpalmer%2Fshelf) [![Build Status](https://travis-ci.org/oscarpalmer/shelf.png?branch=master)](https://travis-ci.org/oscarpalmer/shelf) [![Coverage Status](https://coveralls.io/repos/oscarpalmer/shelf/badge.png?branch=master)](https://coveralls.io/r/oscarpalmer/shelf?branch=master)
+[![PHP version](https://badge.fury.io/ph/oscarpalmer%2Fshelf.png)](http://badge.fury.io/ph/oscarpalmer%2Fshelf) [![Build Status](https://travis-ci.org/oscarpalmer/shelf.png?branch=master)](https://travis-ci.org/oscarpalmer/shelf) [![Coverage](https://codecov.io/gh/oscarpalmer/shelf/branch/master/graph/badge.svg)](https://codecov.io/gh/oscarpalmer/shelf)
 
 Shelf is a [Rack](//rack.github.io)-like interface for PHP `>=5.3`.
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=5.3.0"
   },
   "require-dev": {
-    "league/phpunit-coverage-listener": "dev-master"
+    "phpunit/phpunit": "~4.0"
   },
   "type": "library"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,33 +10,4 @@
       <directory suffix=".php">src/oscarpalmer/Shelf</directory>
     </whitelist>
   </filter>
-  <logging>
-    <log type="coverage-clover" target="/tmp/coverage.xml"/>
-  </logging>
-  <listeners>
-    <listener class="League\PHPUnitCoverageListener\Listener">
-      <arguments>
-        <array>
-          <element key="printer">
-            <object class="League\PHPUnitCoverageListener\Printer\StdOut"/>
-          </element>
-          <element key="hook">
-            <object class="League\PHPUnitCoverageListener\Hook\Travis"/>
-          </element>
-          <element key="namespace">
-            <string>oscarpalmer\Shelf</string>
-          </element>
-          <element key="repo_token">
-            <string>2BuVpcjq1XhVE8znaxsMqjhpFPrYDZ5Ct</string>
-          </element>
-          <element key="target_url">
-            <string>https://coveralls.io/api/v1/jobs</string>
-          </element>
-          <element key="coverage_dir">
-            <string>/tmp</string>
-          </element>
-        </array>
-      </arguments>
-    </listener>
-  </listeners>
 </phpunit>


### PR DESCRIPTION
Switched from Coveralls to Codecov for code coverage and added `7.0`and `7.1`to the list of versions to run tests on with Travis.

Tests passes on `>=5.3`.